### PR TITLE
Add stargate event manager.

### DIFF
--- a/code/sbox_stargate/code/StargateEventManager.cs
+++ b/code/sbox_stargate/code/StargateEventManager.cs
@@ -1,4 +1,4 @@
-﻿namespace Sandbox.sbox_stargate.code
+﻿namespace Sandbox.StargateAddon.code
 {
 	public class StargateEventManager
 	{

--- a/code/sbox_stargate/code/StargateEventManager.cs
+++ b/code/sbox_stargate/code/StargateEventManager.cs
@@ -1,0 +1,95 @@
+﻿namespace Sandbox.sbox_stargate.code
+{
+	public class StargateEventManager
+	{
+		public void RunGateClosedEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.GateClosed, gate );
+		}
+
+		public void RunChevronEncodedEvent( Stargate gate, int num )
+		{
+			Event.Run( StargateEvent.ChevronEncoded, gate, num );
+		}
+
+		public void RunChevronLockedEvent( Stargate gate, int num, bool valid )
+		{
+			Event.Run( StargateEvent.ChevronLocked, gate, num, valid );
+		}
+
+		public void RunDHDChevronEncodedEvent( Stargate gate, char sym )
+		{
+			Event.Run( StargateEvent.DHDChevronEncoded, gate, sym );
+		}
+
+		public void RunDHDChevronLockedEvent( Stargate gate, char sym, bool valid )
+		{
+			Event.Run( StargateEvent.DHDChevronLocked, gate, sym, valid );
+		}
+
+		public void RunDHDChevronUnlockedEvent( Stargate gate, char sym )
+		{
+			Event.Run( StargateEvent.DHDChevronUnlocked, gate, sym );
+		}
+
+		public void RunRingSpinDownEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.RingSpinDown, gate );
+		}
+
+		public void RunReachedDialingSymbolEvent( Stargate gate, char sym )
+		{
+			Event.Run( StargateEvent.ReachedDialingSymbol, gate, sym );
+		}
+
+		public void RunDialBeginEvent( Stargate gate, string address )
+		{
+			Event.Run( StargateEvent.DialBegin, gate, address );
+		}
+
+		public void RunInboundBeginEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.InboundBegin, gate );
+		}
+
+		public void RunDialAbortFinishedEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.DialAbortFinished, gate );
+		}
+
+		public void RunResetEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.Reset, gate );
+		}
+
+		public void RunInboundAbortEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.InboundAbort, gate );
+		}
+
+		public void RunDialAbortEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.DialAbort, gate );
+		}
+
+		public void RunGateOpeningEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.GateOpening, gate );
+		}
+
+		public void RunGateOpenEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.GateOpen, gate );
+		}
+
+		public void RunGateClosingEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.GateClosing, gate );
+		}
+
+		public void RunRingStoppedEvent( Stargate gate )
+		{
+			Event.Run( StargateEvent.RingStopped, gate );
+		}
+	}
+}

--- a/code/sbox_stargate/code/StargateEventManager.cs
+++ b/code/sbox_stargate/code/StargateEventManager.cs
@@ -2,92 +2,92 @@
 {
 	public class StargateEventManager
 	{
-		public void RunGateClosedEvent( Stargate gate )
+		public void GateClosed( Stargate gate )
 		{
 			Event.Run( StargateEvent.GateClosed, gate );
 		}
 
-		public void RunChevronEncodedEvent( Stargate gate, int num )
+		public void ChevronEncoded( Stargate gate, int num )
 		{
 			Event.Run( StargateEvent.ChevronEncoded, gate, num );
 		}
 
-		public void RunChevronLockedEvent( Stargate gate, int num, bool valid )
+		public void ChevronLocked( Stargate gate, int num, bool valid )
 		{
 			Event.Run( StargateEvent.ChevronLocked, gate, num, valid );
 		}
 
-		public void RunDHDChevronEncodedEvent( Stargate gate, char sym )
+		public void DHDChevronEncoded( Stargate gate, char sym )
 		{
 			Event.Run( StargateEvent.DHDChevronEncoded, gate, sym );
 		}
 
-		public void RunDHDChevronLockedEvent( Stargate gate, char sym, bool valid )
+		public void DHDChevronLocked( Stargate gate, char sym, bool valid )
 		{
 			Event.Run( StargateEvent.DHDChevronLocked, gate, sym, valid );
 		}
 
-		public void RunDHDChevronUnlockedEvent( Stargate gate, char sym )
+		public void DHDChevronUnlocked( Stargate gate, char sym )
 		{
 			Event.Run( StargateEvent.DHDChevronUnlocked, gate, sym );
 		}
 
-		public void RunRingSpinDownEvent( Stargate gate )
+		public void RingSpinDown( Stargate gate )
 		{
 			Event.Run( StargateEvent.RingSpinDown, gate );
 		}
 
-		public void RunReachedDialingSymbolEvent( Stargate gate, char sym )
+		public void ReachedDialingSymbol( Stargate gate, char sym )
 		{
 			Event.Run( StargateEvent.ReachedDialingSymbol, gate, sym );
 		}
 
-		public void RunDialBeginEvent( Stargate gate, string address )
+		public void DialBegin( Stargate gate, string address )
 		{
 			Event.Run( StargateEvent.DialBegin, gate, address );
 		}
 
-		public void RunInboundBeginEvent( Stargate gate )
+		public void InboundBegin( Stargate gate )
 		{
 			Event.Run( StargateEvent.InboundBegin, gate );
 		}
 
-		public void RunDialAbortFinishedEvent( Stargate gate )
+		public void DialAbortFinished( Stargate gate )
 		{
 			Event.Run( StargateEvent.DialAbortFinished, gate );
 		}
 
-		public void RunResetEvent( Stargate gate )
+		public void Reset( Stargate gate )
 		{
 			Event.Run( StargateEvent.Reset, gate );
 		}
 
-		public void RunInboundAbortEvent( Stargate gate )
+		public void InboundAbort( Stargate gate )
 		{
 			Event.Run( StargateEvent.InboundAbort, gate );
 		}
 
-		public void RunDialAbortEvent( Stargate gate )
+		public void DialAbort( Stargate gate )
 		{
 			Event.Run( StargateEvent.DialAbort, gate );
 		}
 
-		public void RunGateOpeningEvent( Stargate gate )
+		public void GateOpening( Stargate gate )
 		{
 			Event.Run( StargateEvent.GateOpening, gate );
 		}
 
-		public void RunGateOpenEvent( Stargate gate )
+		public void GateOpen( Stargate gate )
 		{
 			Event.Run( StargateEvent.GateOpen, gate );
 		}
 
-		public void RunGateClosingEvent( Stargate gate )
+		public void GateClosing( Stargate gate )
 		{
 			Event.Run( StargateEvent.GateClosing, gate );
 		}
 
-		public void RunRingStoppedEvent( Stargate gate )
+		public void RingStopped( Stargate gate )
 		{
 			Event.Run( StargateEvent.RingStopped, gate );
 		}

--- a/code/sbox_stargate/entities/stargate_base/Stargate.cs
+++ b/code/sbox_stargate/entities/stargate_base/Stargate.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Sandbox;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 using System.Net;
-using Sandbox.sbox_stargate.code;
+using Sandbox.StargateAddon.code;
 
 [Category( "Stargates" )]
 public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInputEntity

--- a/code/sbox_stargate/entities/stargate_base/Stargate.cs
+++ b/code/sbox_stargate/entities/stargate_base/Stargate.cs
@@ -545,11 +545,11 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 
 		if (Inbound)
 		{
-			StargateEventManager.RunInboundBeginEvent( gate: this );
+			StargateEventManager.InboundBegin( gate: this );
 		}
 		else
 		{
-			StargateEventManager.RunDialAbortEvent( gate: this );
+			StargateEventManager.DialAbort( gate: this );
 		}
 
 		ClearTasksByCategory( TimedTaskCategory.DIALING );
@@ -565,7 +565,7 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 	public virtual void OnStopDialingFinish()
 	{
 		ResetGateVariablesToIdle();
-		StargateEventManager.RunDialAbortFinishedEvent( gate: this );
+		StargateEventManager.DialAbortFinished( gate: this );
 	}
 
 	// opening
@@ -573,14 +573,14 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 	{
 		CurGateState = GateState.OPENING;
 		Busy = true;
-		StargateEventManager.RunGateOpeningEvent( gate: this );
+		StargateEventManager.GateOpening( gate: this );
 	}
 
 	public virtual void OnStargateOpened()
 	{
 		CurGateState = GateState.OPEN;
 		Busy = false;
-		StargateEventManager.RunGateOpenEvent( gate: this );
+		StargateEventManager.GateOpen( gate: this );
 	}
 
 	// closing
@@ -590,13 +590,13 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 		Busy = true;
 
 		KillAllPlayersInTransit();
-		StargateEventManager.RunGateClosingEvent( gate: this );
+		StargateEventManager.GateClosing( gate: this );
 	}
 
 	public virtual void OnStargateClosed()
 	{
 		ResetGateVariablesToIdle();
-		StargateEventManager.RunGateClosedEvent( gate: this );
+		StargateEventManager.GateClosed( gate: this );
 	}
 
 	// reset
@@ -605,7 +605,7 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 		ResetGateVariablesToIdle();
 		ClearTasks();
 
-		StargateEventManager.RunResetEvent( gate: this );
+		StargateEventManager.Reset( gate: this );
 	}
 
 	public virtual void EstablishWormholeTo(Stargate target)
@@ -694,7 +694,7 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 		}
 
 		DialingAddress += symbols;
-		StargateEventManager.RunDHDChevronEncodedEvent( gate: this, symbols );
+		StargateEventManager.DHDChevronEncoded( gate: this, symbols );
 	}
 
 	public virtual void DoDHDChevronLock( char symbols )
@@ -716,7 +716,7 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 		IsLocked = true;
 		IsLockedInvalid = !isStargateReadyForInboundDhd;
 
-		StargateEventManager.RunDHDChevronLockedEvent( gate: this, symbols, isStargateReadyForInboundDhd);
+		StargateEventManager.DHDChevronLocked( gate: this, symbols, isStargateReadyForInboundDhd);
 	}
 
 	// Manual/Slow Chevron Encode/Lock
@@ -750,7 +750,7 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 			CurGateState = GateState.DIALING;
 			CurDialType = DialType.MANUAL;
 
-			StargateEventManager.RunDialBeginEvent( gate: this, address: string.Empty );
+			StargateEventManager.DialBegin( gate: this, address: string.Empty );
 		}
 
 		TimeSinceDialAction = 0;

--- a/code/sbox_stargate/entities/stargate_base/Stargate.cs
+++ b/code/sbox_stargate/entities/stargate_base/Stargate.cs
@@ -676,9 +676,9 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 	}
 
 	// DHD/Fast Chevron Encode/Lock
-	public virtual void DoDHDChevronEncode(char symbols)
+	public virtual void DoDHDChevronEncode(char symbol)
 	{
-		if ( DialingAddress.Contains( symbols ) )
+		if ( DialingAddress.Contains( symbol ) )
 			return;
 
 		// if we were already dialing but not via DHD, dont do anything
@@ -693,8 +693,8 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 			CurDialType = DialType.DHD;
 		}
 
-		DialingAddress += symbols;
-		StargateEventManager.DHDChevronEncoded( gate: this, symbols );
+		DialingAddress += symbol;
+		StargateEventManager.DHDChevronEncoded( gate: this, symbol );
 	}
 
 	public virtual void DoDHDChevronLock( char symbols )
@@ -731,7 +731,7 @@ public abstract partial class Stargate : Prop, IUse, IWireOutputEntity, IWireInp
 			DoManualChevronLock( sym );
 			return false;
 		}
-			
+
 		if ( !CanStargateStartManualDial() )
 			return false;
 

--- a/code/sbox_stargate/entities/stargate_base/StargateEvent.cs
+++ b/code/sbox_stargate/entities/stargate_base/StargateEvent.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Sandbox;
-using Sandbox.UI;
+﻿using Sandbox;
 
 public static class StargateEvent
 {

--- a/code/sbox_stargate/entities/stargate_milkyway/StargateMilkyWay.cs
+++ b/code/sbox_stargate/entities/stargate_milkyway/StargateMilkyWay.cs
@@ -5,7 +5,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Editor;
 using Sandbox;
-using Sandbox.sbox_stargate.code;
+using Sandbox.StargateAddon.code;
 
 [HammerEntity, SupportsSolid, EditorModel( MODEL )]
 [Title( "Stargate (Milky Way)" ), Category( "Stargate" ), Icon( "chair" ), Spawnable]

--- a/code/sbox_stargate/entities/stargate_milkyway/StargateMilkyWay.cs
+++ b/code/sbox_stargate/entities/stargate_milkyway/StargateMilkyWay.cs
@@ -282,7 +282,7 @@ public partial class StargateMilkyWay : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent( gate: this, address );
+		StargateEventManager.DialBegin( gate: this, address );
 
 		try
 		{
@@ -337,7 +337,7 @@ public partial class StargateMilkyWay : Stargate
 
 					ActiveChevrons++;
 					CurDialingSymbol = address[currentChevronPosition - 1];
-					StargateEventManager.RunChevronEncodedEvent( gate: this, currentChevronPosition );
+					StargateEventManager.ChevronEncoded( gate: this, currentChevronPosition );
 				}
 
 				if ( currentChevronPosition == addrLen - 1 ) Ring.SpinDown(); // stop rotating ring when the last looped chevron locks
@@ -368,7 +368,7 @@ public partial class StargateMilkyWay : Stargate
 
 				CurDialingSymbol = address[addrLen - 1];
 
-				StargateEventManager.RunChevronLockedEvent( gate: this, address.Length, readyForOpen );
+				StargateEventManager.ChevronLocked( gate: this, address.Length, readyForOpen );
 
 				if ( MovieDialingType )
 				{
@@ -412,7 +412,7 @@ public partial class StargateMilkyWay : Stargate
 
 		if ( !IsStargateReadyForInboundFast() ) return;
 
-		StargateEventManager.RunInboundBeginEvent( gate: this );
+		StargateEventManager.InboundBegin( gate: this );
 
 		try
 		{
@@ -483,7 +483,7 @@ public partial class StargateMilkyWay : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent( gate: this, address );
+		StargateEventManager.DialBegin( gate: this, address );
 
 		try
 		{
@@ -552,7 +552,7 @@ public partial class StargateMilkyWay : Stargate
 						if ( ChevronLightup ) chev.TurnOn( 0.5f );
 					}
 
-					StargateEventManager.RunChevronEncodedEvent( gate: this, chevNum);
+					StargateEventManager.ChevronEncoded( gate: this, chevNum);
 				}
 				else
 				{
@@ -569,7 +569,7 @@ public partial class StargateMilkyWay : Stargate
 					IsLocked = true;
 					IsLockedInvalid = !valid;
 
-					StargateEventManager.RunChevronLockedEvent( gate: this, chevNum, valid );
+					StargateEventManager.ChevronLocked( gate: this, chevNum, valid );
 				}
 
 				ActiveChevrons++;
@@ -620,7 +620,7 @@ public partial class StargateMilkyWay : Stargate
 
 		if ( !IsStargateReadyForInboundInstantSlow() ) return;
 
-		StargateEventManager.RunInboundBeginEvent( gate: this );
+		StargateEventManager.InboundBegin( gate: this );
 
 		try
 		{
@@ -659,7 +659,7 @@ public partial class StargateMilkyWay : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent( gate: this, address );
+		StargateEventManager.DialBegin( gate: this, address );
 
 		try
 		{
@@ -749,7 +749,7 @@ public partial class StargateMilkyWay : Stargate
 
 		if ( !IsStargateReadyForInboundDHD() ) return;
 
-		StargateEventManager.RunInboundBeginEvent( gate: this );
+		StargateEventManager.InboundBegin( gate: this );
 
 		try
 		{
@@ -852,7 +852,7 @@ public partial class StargateMilkyWay : Stargate
 		DialingAddress += sym;
 		ActiveChevrons++;
 
-		StargateEventManager.RunChevronEncodedEvent( gate: this, chevNum );
+		StargateEventManager.ChevronEncoded( gate: this, chevNum );
 
 		IsManualDialInProgress = false;
 
@@ -906,7 +906,7 @@ public partial class StargateMilkyWay : Stargate
 		IsLocked = true;
 		IsLockedInvalid = !valid;
 
-		StargateEventManager.RunChevronLockedEvent( gate: this, chevNum, valid );
+		StargateEventManager.ChevronLocked( gate: this, chevNum, valid );
 
 		await GameTask.DelaySeconds( 0.75f );
 

--- a/code/sbox_stargate/entities/stargate_milkyway/StargateMilkyWay.cs
+++ b/code/sbox_stargate/entities/stargate_milkyway/StargateMilkyWay.cs
@@ -773,9 +773,9 @@ public partial class StargateMilkyWay : Stargate
 	}
 
 	// CHEVRON STUFF - DHD DIALING
-	public override void DoDHDChevronEncode( char symbols )
+	public override void DoDHDChevronEncode( char symbol )
 	{
-		base.DoDHDChevronEncode( symbols );
+		base.DoDHDChevronEncode( symbol );
 
 		var chev = GetChevronBasedOnAddressLength( DialingAddress.Length, 9 );
 		EncodedChevronsOrdered.Add( chev );

--- a/code/sbox_stargate/entities/stargate_milkyway/StargateRingMilkyWay.cs
+++ b/code/sbox_stargate/entities/stargate_milkyway/StargateRingMilkyWay.cs
@@ -128,7 +128,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 		ShouldDecc = false;
 		ShouldAcc = true;
 
-		_stargateEventManager.RunInboundBeginEvent( Gate );
+		_stargateEventManager.InboundBegin( Gate );
 	}
 
 	TimeSince lastSpinDown = 0;
@@ -141,7 +141,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 		ShouldAcc = false;
 		ShouldDecc = true;
 
-		_stargateEventManager.RunRingSpinDownEvent( Gate );
+		_stargateEventManager.RingSpinDown( Gate );
 
 		if ( StopSoundOnSpinDown )
 		{
@@ -160,7 +160,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 		if (Gate.IsValid())
 		{
 			hasReachedDialingSymbol = false;
-			_stargateEventManager.RunRingStoppedEvent( Gate );
+			_stargateEventManager.RingStopped( Gate );
 			if ( !StopSoundOnSpinDown )
 			{
 				PlayStopSound();
@@ -295,7 +295,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 					if ( CurRingSymbol == CurDialingSymbol && Gate.Dialing )
 					{
 						hasReachedDialingSymbol = true;
-						_stargateEventManager.RunReachedDialingSymbolEvent( Gate, CurDialingSymbol );
+						_stargateEventManager.ReachedDialingSymbol( Gate, CurDialingSymbol );
 					}
 				}
 			}

--- a/code/sbox_stargate/entities/stargate_milkyway/StargateRingMilkyWay.cs
+++ b/code/sbox_stargate/entities/stargate_milkyway/StargateRingMilkyWay.cs
@@ -4,9 +4,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Sandbox;
+using Sandbox.sbox_stargate.code;
 
 public partial class StargateRingMilkyWay : StargatePlatformEntity
 {
+	public StargateRingMilkyWay()
+	{
+		_stargateEventManager = new StargateEventManager();
+	}
+
 	// ring variables
 
 	[Net]
@@ -23,6 +29,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 	public char CurRingSymbol { get; private set; } = ' ';
 	public float TargetRingAngle { get; private set; } = 0.0f;
 
+	private StargateEventManager _stargateEventManager;
 	private float RingCurSpeed = 0f;
 	protected float RingMaxSpeed = 50f;
 	protected float RingAccelStep = 1f;
@@ -121,7 +128,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 		ShouldDecc = false;
 		ShouldAcc = true;
 
-		Event.Run( StargateEvent.RingSpinUp, Gate );
+		_stargateEventManager.RunInboundBeginEvent( Gate );
 	}
 
 	TimeSince lastSpinDown = 0;
@@ -134,7 +141,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 		ShouldAcc = false;
 		ShouldDecc = true;
 
-		Event.Run( StargateEvent.RingSpinDown, Gate );
+		_stargateEventManager.RunRingSpinDownEvent( Gate );
 
 		if ( StopSoundOnSpinDown )
 		{
@@ -153,7 +160,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 		if (Gate.IsValid())
 		{
 			hasReachedDialingSymbol = false;
-			Event.Run( StargateEvent.RingStopped, Gate );
+			_stargateEventManager.RunRingStoppedEvent( Gate );
 			if ( !StopSoundOnSpinDown )
 			{
 				PlayStopSound();
@@ -288,7 +295,7 @@ public partial class StargateRingMilkyWay : StargatePlatformEntity
 					if ( CurRingSymbol == CurDialingSymbol && Gate.Dialing )
 					{
 						hasReachedDialingSymbol = true;
-						Event.Run( StargateEvent.ReachedDialingSymbol, Gate, CurDialingSymbol );
+						_stargateEventManager.RunReachedDialingSymbolEvent( Gate, CurDialingSymbol );
 					}
 				}
 			}

--- a/code/sbox_stargate/entities/stargate_milkyway/StargateRingMilkyWay.cs
+++ b/code/sbox_stargate/entities/stargate_milkyway/StargateRingMilkyWay.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Sandbox;
-using Sandbox.sbox_stargate.code;
+using Sandbox.StargateAddon.code;
 
 public partial class StargateRingMilkyWay : StargatePlatformEntity
 {

--- a/code/sbox_stargate/entities/stargate_pegasus/StargatePegasus.cs
+++ b/code/sbox_stargate/entities/stargate_pegasus/StargatePegasus.cs
@@ -207,7 +207,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent( gate: this, address );
+		StargateEventManager.DialBegin( gate: this, address );
 
 		try
 		{
@@ -263,7 +263,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !IsStargateReadyForInboundFast() ) return;
 
-		StargateEventManager.RunInboundBeginEvent( gate: this );
+		StargateEventManager.InboundBegin( gate: this );
 
 		try
 		{
@@ -293,7 +293,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent( gate: this, address );
+		StargateEventManager.DialBegin( gate: this, address );
 
 		try
 		{
@@ -366,7 +366,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !IsStargateReadyForInboundInstantSlow() ) return;
 
-		StargateEventManager.RunInboundBeginEvent( gate: this );
+		StargateEventManager.InboundBegin( gate: this );
 
 		try
 		{
@@ -398,7 +398,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent(gate: this, address);
+		StargateEventManager.DialBegin(gate: this, address);
 
 		try
 		{
@@ -482,7 +482,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !IsStargateReadyForInboundDHD() ) return;
 
-		StargateEventManager.RunInboundBeginEvent(gate: this);
+		StargateEventManager.InboundBegin(gate: this);
 
 		try
 		{
@@ -561,7 +561,7 @@ public partial class StargatePegasus : Stargate
 		//var chev = GetChevronBasedOnAddressLength( 7, 8 );
 		ChevronActivateDHD( chev, 0, true );
 
-		StargateEventManager.RunChevronEncodedEvent( gate: this, chevNum );
+		StargateEventManager.ChevronEncoded( gate: this, chevNum );
 
 		IsManualDialInProgress = false;
 
@@ -604,7 +604,7 @@ public partial class StargatePegasus : Stargate
 		if (isValid)
 			ActiveChevrons++;
 
-		StargateEventManager.RunChevronLockedEvent( gate: this, chevNum, isValid );
+		StargateEventManager.ChevronLocked( gate: this, chevNum, isValid );
 
 		TimeSinceDialAction = 0;
 

--- a/code/sbox_stargate/entities/stargate_pegasus/StargatePegasus.cs
+++ b/code/sbox_stargate/entities/stargate_pegasus/StargatePegasus.cs
@@ -207,7 +207,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		Event.Run( StargateEvent.DialBegin, this, address );
+		StargateEventManager.RunDialBeginEvent( gate: this, address );
 
 		try
 		{
@@ -263,7 +263,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !IsStargateReadyForInboundFast() ) return;
 
-		Event.Run( StargateEvent.InboundBegin, this );
+		StargateEventManager.RunInboundBeginEvent( gate: this );
 
 		try
 		{
@@ -293,7 +293,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		Event.Run( StargateEvent.DialBegin, this, address );
+		StargateEventManager.RunDialBeginEvent( gate: this, address );
 
 		try
 		{
@@ -366,7 +366,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !IsStargateReadyForInboundInstantSlow() ) return;
 
-		Event.Run( StargateEvent.InboundBegin, this );
+		StargateEventManager.RunInboundBeginEvent( gate: this );
 
 		try
 		{
@@ -398,7 +398,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		Event.Run( StargateEvent.DialBegin, this, address );
+		StargateEventManager.RunDialBeginEvent(gate: this, address);
 
 		try
 		{
@@ -482,7 +482,7 @@ public partial class StargatePegasus : Stargate
 
 		if ( !IsStargateReadyForInboundDHD() ) return;
 
-		Event.Run( StargateEvent.InboundBegin, this );
+		StargateEventManager.RunInboundBeginEvent(gate: this);
 
 		try
 		{
@@ -505,9 +505,9 @@ public partial class StargatePegasus : Stargate
 	}
 
 	// CHEVRON STUFF - DHD DIALING
-	public override void DoDHDChevronEncode(char sym)
+	public override void DoDHDChevronEncode(char symbols)
 	{
-		base.DoDHDChevronEncode( sym );
+		base.DoDHDChevronEncode( symbols );
 
 		var clampLen = Math.Clamp( DialingAddress.Length + 1, 7, 9 );
 
@@ -517,9 +517,9 @@ public partial class StargatePegasus : Stargate
 		Ring.RollSymbolDHDFast( clampLen, () => true, DialingAddress.Length, 0.6f );
 	}
 
-	public override void DoDHDChevronLock( char sym ) // only the top chevron locks, always
+	public override void DoDHDChevronLock( char symbols ) // only the top chevron locks, always
 	{
-		base.DoDHDChevronLock( sym );
+		base.DoDHDChevronLock( symbols );
 
 		var chev = GetTopChevron();
 		EncodedChevronsOrdered.Add( chev );
@@ -561,7 +561,7 @@ public partial class StargatePegasus : Stargate
 		//var chev = GetChevronBasedOnAddressLength( 7, 8 );
 		ChevronActivateDHD( chev, 0, true );
 
-		Event.Run( StargateEvent.ChevronEncoded, this, chevNum );
+		StargateEventManager.RunChevronEncodedEvent( gate: this, chevNum );
 
 		IsManualDialInProgress = false;
 
@@ -604,7 +604,7 @@ public partial class StargatePegasus : Stargate
 		if (isValid)
 			ActiveChevrons++;
 
-		Event.Run( StargateEvent.ChevronLocked, this, chevNum, isValid );
+		StargateEventManager.RunChevronLockedEvent( gate: this, chevNum, isValid );
 
 		TimeSinceDialAction = 0;
 

--- a/code/sbox_stargate/entities/stargate_pegasus/StargatePegasus.cs
+++ b/code/sbox_stargate/entities/stargate_pegasus/StargatePegasus.cs
@@ -505,9 +505,9 @@ public partial class StargatePegasus : Stargate
 	}
 
 	// CHEVRON STUFF - DHD DIALING
-	public override void DoDHDChevronEncode(char symbols)
+	public override void DoDHDChevronEncode(char symbol)
 	{
-		base.DoDHDChevronEncode( symbols );
+		base.DoDHDChevronEncode( symbol );
 
 		var clampLen = Math.Clamp( DialingAddress.Length + 1, 7, 9 );
 

--- a/code/sbox_stargate/entities/stargate_pegasus/StargateRingPegasus.cs
+++ b/code/sbox_stargate/entities/stargate_pegasus/StargateRingPegasus.cs
@@ -6,7 +6,7 @@ using System.Net.NetworkInformation;
 using System.Text;
 using System.Threading.Tasks;
 using Sandbox;
-using Sandbox.sbox_stargate.code;
+using Sandbox.StargateAddon.code;
 
 public partial class StargateRingPegasus : ModelEntity
 {

--- a/code/sbox_stargate/entities/stargate_pegasus/StargateRingPegasus.cs
+++ b/code/sbox_stargate/entities/stargate_pegasus/StargateRingPegasus.cs
@@ -6,9 +6,15 @@ using System.Net.NetworkInformation;
 using System.Text;
 using System.Threading.Tasks;
 using Sandbox;
+using Sandbox.sbox_stargate.code;
 
 public partial class StargateRingPegasus : ModelEntity
 {
+	public StargateRingPegasus()
+	{
+		_stargateEventManager = new StargateEventManager();
+	}
+
 	// ring variables
 
 	[Net]
@@ -22,7 +28,7 @@ public partial class StargateRingPegasus : ModelEntity
 	public List<int> DialSequenceActiveSymbols { get; private set; } = new();
 
 	private Sound? RollSound = null;
-
+	private StargateEventManager _stargateEventManager;
 
 	public override void Spawn()
 	{
@@ -337,7 +343,8 @@ public partial class StargateRingPegasus : ModelEntity
 					if ( i_copy < chevCount - 1 )
 					{
 						Gate.ChevronActivateDHD( chev, 0, true );
-						Event.Run( StargateEvent.ChevronEncoded, Gate, i_copy + 1 );
+						// wtf magic number TODO: why plus one?
+						_stargateEventManager.RunChevronEncodedEvent( Gate, i_copy + 1 );
 					}
 					else
 					{
@@ -346,7 +353,8 @@ public partial class StargateRingPegasus : ModelEntity
 						Gate.IsLockedInvalid = !isValid;
 
 						Gate.ChevronActivate( chev, 0, isValid, true );
-						Event.Run( StargateEvent.ChevronLocked, Gate, i_copy + 1, isValid );
+						// wtf magic number TODO: why plus one?
+						_stargateEventManager.RunChevronLockedEvent( Gate, i_copy + 1, isValid );
 					}
 				}
 				Gate.AddTask( chevTaskTime, chevTask, Stargate.TimedTaskCategory.DIALING );
@@ -394,16 +402,15 @@ public partial class StargateRingPegasus : ModelEntity
 					Gate.ChevronActivate( Gate.GetChevronBasedOnAddressLength( i_copy + 1, chevCount ), 0, isLastChev ? validCheck() : true, isLastChev );
 					if (!isLastChev)
 					{
-						Event.Run( StargateEvent.ChevronEncoded, Gate, i_copy + 1 );
+						_stargateEventManager.RunChevronEncodedEvent( Gate, i_copy + 1 );
 					}
 					else
 					{
 						Gate.IsLocked = true;
 						Gate.IsLockedInvalid = !validCheck();
 
-						Event.Run( StargateEvent.ChevronLocked, Gate, i_copy + 1, validCheck() );
+						_stargateEventManager.RunChevronLockedEvent( Gate, i_copy + 1, validCheck() );
 					}
-					
 				}, Stargate.TimedTaskCategory.DIALING );
 			}
 		}

--- a/code/sbox_stargate/entities/stargate_pegasus/StargateRingPegasus.cs
+++ b/code/sbox_stargate/entities/stargate_pegasus/StargateRingPegasus.cs
@@ -344,7 +344,7 @@ public partial class StargateRingPegasus : ModelEntity
 					{
 						Gate.ChevronActivateDHD( chev, 0, true );
 						// wtf magic number TODO: why plus one?
-						_stargateEventManager.RunChevronEncodedEvent( Gate, i_copy + 1 );
+						_stargateEventManager.ChevronEncoded( Gate, i_copy + 1 );
 					}
 					else
 					{
@@ -354,7 +354,7 @@ public partial class StargateRingPegasus : ModelEntity
 
 						Gate.ChevronActivate( chev, 0, isValid, true );
 						// wtf magic number TODO: why plus one?
-						_stargateEventManager.RunChevronLockedEvent( Gate, i_copy + 1, isValid );
+						_stargateEventManager.ChevronLocked( Gate, i_copy + 1, isValid );
 					}
 				}
 				Gate.AddTask( chevTaskTime, chevTask, Stargate.TimedTaskCategory.DIALING );
@@ -402,14 +402,14 @@ public partial class StargateRingPegasus : ModelEntity
 					Gate.ChevronActivate( Gate.GetChevronBasedOnAddressLength( i_copy + 1, chevCount ), 0, isLastChev ? validCheck() : true, isLastChev );
 					if (!isLastChev)
 					{
-						_stargateEventManager.RunChevronEncodedEvent( Gate, i_copy + 1 );
+						_stargateEventManager.ChevronEncoded( Gate, i_copy + 1 );
 					}
 					else
 					{
 						Gate.IsLocked = true;
 						Gate.IsLockedInvalid = !validCheck();
 
-						_stargateEventManager.RunChevronLockedEvent( Gate, i_copy + 1, validCheck() );
+						_stargateEventManager.ChevronLocked( Gate, i_copy + 1, validCheck() );
 					}
 				}, Stargate.TimedTaskCategory.DIALING );
 			}

--- a/code/sbox_stargate/entities/stargate_universe/StargateUniverse.cs
+++ b/code/sbox_stargate/entities/stargate_universe/StargateUniverse.cs
@@ -223,7 +223,7 @@ public partial class StargateUniverse : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent( gate: this, address );
+		StargateEventManager.DialBegin( gate: this, address );
 
 		try
 		{
@@ -273,7 +273,7 @@ public partial class StargateUniverse : Stargate
 					var isLastChev = i_copy == addrLen - 1;
 					if (!isLastChev)
 					{
-						StargateEventManager.RunChevronEncodedEvent( gate: this, i_copy + 1 );
+						StargateEventManager.ChevronEncoded( gate: this, i_copy + 1 );
 					}
 					else
 					{
@@ -282,7 +282,7 @@ public partial class StargateUniverse : Stargate
 						IsLocked = true;
 						IsLockedInvalid = !isValid;
 
-						StargateEventManager.RunChevronLockedEvent( gate: this, i_copy + 1, isValid );
+						StargateEventManager.ChevronLocked( gate: this, i_copy + 1, isValid );
 					}
 				}, TimedTaskCategory.DIALING );
 			}
@@ -316,7 +316,7 @@ public partial class StargateUniverse : Stargate
 
 		if ( !IsStargateReadyForInboundFast() ) return;
 
-		StargateEventManager.RunInboundBeginEvent( gate: this);
+		StargateEventManager.InboundBegin( gate: this);
 
 		try
 		{
@@ -347,7 +347,7 @@ public partial class StargateUniverse : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent( gate: this, address );
+		StargateEventManager.DialBegin( gate: this, address );
 
 		try
 		{
@@ -413,7 +413,7 @@ public partial class StargateUniverse : Stargate
 					{
 						Bearing?.TurnOff( 0.6f );
 						// TODO: magic number
-						StargateEventManager.RunChevronEncodedEvent( gate: this, address.IndexOf( sym ) + 1 );
+						StargateEventManager.ChevronEncoded( gate: this, address.IndexOf( sym ) + 1 );
 					}
 					else
 					{
@@ -423,7 +423,7 @@ public partial class StargateUniverse : Stargate
 						IsLockedInvalid = !isValid;
 
 						// TODO: magic number
-						StargateEventManager.RunChevronLockedEvent( gate: this, address.IndexOf( sym ) + 1, isValid );
+						StargateEventManager.ChevronLocked( gate: this, address.IndexOf( sym ) + 1, isValid );
 					}
 				}
 
@@ -461,7 +461,7 @@ public partial class StargateUniverse : Stargate
 
 		if ( !IsStargateReadyForInboundInstantSlow() ) return;
 
-		StargateEventManager.RunInboundBeginEvent( gate: this );
+		StargateEventManager.InboundBegin( gate: this );
 
 		try
 		{
@@ -486,7 +486,7 @@ public partial class StargateUniverse : Stargate
 
 		if ( !CanStargateStartDial() ) return;
 
-		StargateEventManager.RunDialBeginEvent( gate: this, address );
+		StargateEventManager.DialBegin( gate: this, address );
 
 		try
 		{
@@ -570,7 +570,7 @@ public partial class StargateUniverse : Stargate
 
 		if ( !IsStargateReadyForInboundDHD() ) return;
 
-		StargateEventManager.RunInboundBeginEvent( gate: this );
+		StargateEventManager.InboundBegin( gate: this );
 
 		try
 		{
@@ -636,7 +636,7 @@ public partial class StargateUniverse : Stargate
 			ActiveChevrons++;
 
 			Bearing?.TurnOff( 0.6f );
-			StargateEventManager.RunChevronEncodedEvent( gate: this, chevNum );
+			StargateEventManager.ChevronEncoded( gate: this, chevNum );
 		}
 
 		AddTask( Time.Now + 0.65f, symbolAction, TimedTaskCategory.DIALING );
@@ -693,7 +693,7 @@ public partial class StargateUniverse : Stargate
 			IsLocked = true;
 			IsLockedInvalid = !isValid;
 
-			StargateEventManager.RunChevronLockedEvent( gate: this, DialingAddress.Length, isValid);
+			StargateEventManager.ChevronLocked( gate: this, DialingAddress.Length, isValid);
 		}
 
 		AddTask( Time.Now + 0.65f, symbolAction, TimedTaskCategory.DIALING );

--- a/code/sbox_stargate/entities/stargate_universe/StargateUniverse.cs
+++ b/code/sbox_stargate/entities/stargate_universe/StargateUniverse.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Editor;
 using Sandbox;
-using Sandbox.sbox_stargate.code;
+using Sandbox.StargateAddon.code;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 
 [HammerEntity, SupportsSolid, EditorModel( MODEL )]

--- a/code/sbox_stargate/entities/stargate_universe/StargateUniverse.cs
+++ b/code/sbox_stargate/entities/stargate_universe/StargateUniverse.cs
@@ -588,13 +588,13 @@ public partial class StargateUniverse : Stargate
 	}
 
 	// CHEVRON STUFF - DHD DIALING
-	public override void DoDHDChevronEncode( char symbols )
+	public override void DoDHDChevronEncode( char symbol )
 	{
-		base.DoDHDChevronEncode( symbols );
+		base.DoDHDChevronEncode( symbol );
 
 		if ( DialingAddress.Length == 1 ) DoPreRoll();
 
-		AddTask( Time.Now + 0.25f, () => SymbolOn( symbols, DialingAddress.Length == 1 ), TimedTaskCategory.DIALING );
+		AddTask( Time.Now + 0.25f, () => SymbolOn( symbol, DialingAddress.Length == 1 ), TimedTaskCategory.DIALING );
 	}
 
 	public override void DoDHDChevronLock( char symbols ) // only the top chevron locks, always


### PR DESCRIPTION
**Before**
![image](https://github.com/Gmod4phun/sbox-stargate/assets/76946156/a41b684a-f25d-41e8-a8bb-9bae732248e0)

**now (my proposed change)**
![image](https://github.com/Gmod4phun/sbox-stargate/assets/76946156/61ce774a-0890-4228-bd78-c9b40fcd4cec)

there are several reasons why I did it
1) code readability (Event.Run cannot name individual parameters, for example, via generics. the parameters are named arg0,arg1,arg2. which are nameless names that don't say anything.)
2) preventing the event from being used wrong
3) wrapping the layer for better clean architecture
